### PR TITLE
feat(company-guru): create and fetch test table

### DIFF
--- a/packages/company-guru/src/load.ts
+++ b/packages/company-guru/src/load.ts
@@ -1,7 +1,38 @@
+import type { RowDataPacket } from 'mysql2';
+
 import { getPool, initMysql } from './lib/db';
 
-(async () => {
-  await initMysql();
+const createTestTableQuery = `
+  CREATE TABLE IF NOT EXISTS test (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+`;
 
-  getPool(); // @todo create table test
+(async () => {
+  let pool: ReturnType<typeof getPool> | null = null;
+
+  try {
+    await initMysql();
+
+    pool = getPool();
+
+    await pool.execute(createTestTableQuery);
+
+    const [rows] = await pool.query<RowDataPacket[]>(
+      'SELECT id, name, created_at, updated_at FROM test ORDER BY id ASC'
+    );
+
+    console.log('Fetched rows from test table:', rows);
+  } catch (error) {
+    console.error('Failed to initialize test table:', error);
+    process.exitCode = 1;
+  } finally {
+    if (pool) {
+      await pool.end();
+    }
+  }
 })();


### PR DESCRIPTION
## Summary
- create a reusable query for initializing the `test` table structure
- execute the query during the load script and fetch ordered results from the table
- ensure the MySQL pool closes after the data is fetched

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68cbbb7e21008333a74e7706c6610b2a