### PR TITLE
Improve advanced search date splitting

### DIFF
--- a/packages/company-guru/src/get-guru-all-companies.ts
+++ b/packages/company-guru/src/get-guru-all-companies.ts
@@ -1,6 +1,5 @@
 import { GuruBase } from './lib/guru-base';
 import { Storage } from './lib/storage';
-import { guruSettings } from './settings';
 import { Tools } from './lib/tools';
 import moment from 'moment';
 import dotenv from 'dotenv';
@@ -12,33 +11,33 @@ class GetGuruAllCompanies extends GuruBase {
    * Load all results split by date
    */
   async loadResults() {
-    for (const [dateFrom, dateTo] of guruSettings.dateChunks) {
-      const continuesKey = `GET-ALL > CHUNK: ${dateFrom.format('YYYY-MM-DD')} <> ${dateTo.format('YYYY-MM-DD')}`;
-      console.log(continuesKey);
+    const dateFrom = this.dateFrom.clone();
+    const dateTo = this.dateTo.clone();
+    const continuesKey = `GET-ALL > RANGE: ${dateFrom.format('YYYY-MM-DD')} <> ${dateTo.format('YYYY-MM-DD')}`;
+    console.log(continuesKey);
 
-      // Check for continues
-      if (await this.storage.cacheContinuesGet(continuesKey)) {
-        console.log('CONTINUES SKIP :)');
-        continue;
-      }
+    // Check for continues
+    if (await this.storage.cacheContinuesGet(continuesKey)) {
+      console.log('CONTINUES SKIP :)');
+      return;
+    }
 
-      for (let rTry = 1; rTry <= 5; rTry++) {
-        try {
-          await this.advancedSearch({}, null, {
-            dateFrom,
-            dateTo,
-          });
+    for (let rTry = 1; rTry <= 5; rTry++) {
+      try {
+        await this.advancedSearch({}, null, {
+          dateFrom: dateFrom.clone(),
+          dateTo: dateTo.clone(),
+        });
 
-          // Save continues
-          await this.storage.cacheContinuesAdd(continuesKey, moment().format('YYYY-MM-DD'));
+        // Save continues
+        await this.storage.cacheContinuesAdd(continuesKey, moment().format('YYYY-MM-DD'));
 
-          // Break the check
-          break;
-        } catch (e) {
-          console.log(`>>> ROOT FAIL / TRY ${rTry} /  SLEEP 10sec. <<<`);
-          console.error(e);
-          await Tools.sleep(10000);
-        }
+        // Break the check
+        break;
+      } catch (e) {
+        console.log(`>>> ROOT FAIL / TRY ${rTry} /  SLEEP 10sec. <<<`);
+        console.error(e);
+        await Tools.sleep(10000);
       }
     }
   }

--- a/packages/company-guru/src/settings.ts
+++ b/packages/company-guru/src/settings.ts
@@ -1,25 +1,5 @@
-import moment from 'moment';
-
 export const guruSettings = {
   requestSleepMs: 130, // ~ 1000 / users
-
-  dateChunks: [
-    [moment('1800-01-01'), moment('1990-01-01')],
-    [moment('1990-01-01'), moment('2000-01-01')],
-    [moment('2000-01-01'), moment('2005-01-01')],
-    [moment('2005-01-01'), moment('2006-01-01')],
-    [moment('2006-01-01'), moment('2007-01-01')],
-    [moment('2007-01-01'), moment('2008-01-01')],
-    [moment('2008-01-01'), moment('2009-01-01')],
-    [moment('2009-01-01'), moment('2010-01-01')],
-    [moment('2010-01-01'), moment('2020-01-01')],
-    [moment('2020-01-01'), moment('2021-12-01')],
-    [moment('2021-12-01'), moment('2022-06-01')],
-    [moment('2022-06-01'), moment('2022-12-01')],
-    [moment('2022-12-01'), moment('2023-06-01')],
-    [moment('2023-06-01'), moment('2023-12-01')],
-    [moment('2023-12-01'), moment()],
-  ],
 
   users: [
     {


### PR DESCRIPTION
## Summary
- update the Company Guru advanced search to recursively split date ranges until the result count fits under the API cap
- rely on the dynamic splitting by removing the static `dateChunks` configuration and updating callers accordingly

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68cbd6dfaf7c8333bf469a679d421c2f